### PR TITLE
Adding /s command for tracking the selling of an item

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 
 | Command | Description | Example |
 | ------- | ----------- | ------- |
-| `/h search_term` | Search for posts where people _have_ \[H] the search_term | `/h Olivia++` |
+| `/h search_term` | Search for posts where people _have_ \[H] the search_term. Only one of `/h` and `/s` can apply to a given item | `/h Olivia++` |
+| `/s search_term` | Search for posts where people _have_ \[H] the search_term and _want_ \[W] Paypal. Only one of `/h` and `/s` can apply to a given item | `/s Botanical` |
 | `/w search_term` | Search for posts where people _want_ \[W] the search_term | `/w Lily58` |
 | `/v search_term` | Search for posts from a specific vendor \[Vendor] | `/v VintKeys` |
 | `/ic search_term` | Search for posts advertising an interest check \[IC] | `/ic Acrylic Case` |

--- a/main.py
+++ b/main.py
@@ -20,6 +20,8 @@ vendor_regex = re.compile(r'\[vendor\](?P<title>.*)')
 groupbuy_regex = re.compile(r'\[gb\](?P<title>.*)')
 ic_regex = re.compile(r'\[ic\](?P<title>.*)')
 
+watchlist_ordered_types = ['h', 'w', 's', 'ic', 'v', 'gb']
+
 class RedditUser():
     def __init__(self, username, message):
         self.username = username
@@ -29,30 +31,15 @@ class RedditUser():
     def update_messages(self, message):
         self.message = message
 
-
     def get_watch_list(self, message):
         user_df = read_df_pickle(user_df_pickle)
         this_user = user_df.loc[self.username]
         body = 'Your current watch list for /r/mechmarket is:\n\n'
-        item_counter = 1
-        for item in this_user['h']:
-            body += str(item_counter)+'. [H] '+item+'\n\n'
-            item_counter += 1
-        for item in this_user['w']:
-            body += str(item_counter)+'. [W] '+item+'\n\n'
-            item_counter += 1
-        for item in this_user['s']:
-            body += str(item_counter)+'. [H] '+item+' + [W] Paypal\n\n'
-            item_counter += 1
-        for item in this_user['ic']:
-            body += str(item_counter)+'. [IC] '+item+'\n\n'
-            item_counter += 1
-        for item in this_user['v']:
-            body += str(item_counter)+'. [V] '+item+'\n\n'
-            item_counter += 1
-        for item in this_user['gb']:
-            body += str(item_counter)+'. [GB] '+item+'\n\n'
-            item_counter += 1
+        item_count = 1
+        for watch_type in watchlist_ordered_types:
+            for item in this_user[watch_type]:
+                    body += get_formatted_watch_list_string(watch_type, item, item_count)
+                    item_count += 1
 
         body += f"Your current location is: {this_user['l'].upper() if this_user['l'] else 'Earth'}"
 
@@ -95,6 +82,10 @@ class RedditUser():
     def send_message(self, body):
         reddit.inbox.message(self.message).reply(body)
 
+def get_formatted_watch_list_string(watch_type, item, item_count):
+        formatted_substring = \
+            f'[H] {item} + [W] Paypal' if watch_type == 's' else f'[{watch_type.upper()}] {item}'
+        return f'{item_count}. {formatted_substring}\n\n'
 
 def lock_controlled_file(func):
     def wrap(*args, **kwargs):
@@ -139,12 +130,11 @@ def alert_interested_users(user_df, user_column, title_text, submission):
 def remove_item_by_index(user_df, author, index):
     index_counter = 0
     this_user = user_df.loc[author]
-    types = ['h', 'w', 'ic', 'v', 'gb']
-    lengths_in_order = [len(this_user.loc[x]) for x in types]
+    lengths_in_order = [len(this_user.loc[x]) for x in watchlist_ordered_types]
     length_so_far = 0
     for i, this_length in enumerate(lengths_in_order):
         if index < length_so_far+this_length:
-            rm_item = user_df.loc[author][types[i]].pop(index-length_so_far)
+            rm_item = user_df.loc[author][watchlist_ordered_types[i]].pop(index-length_so_far)
             user_df.loc[author]['RedditUser'].send_message(f"Removed {rm_item} from watchlist.")
             return user_df
         else:

--- a/main.py
+++ b/main.py
@@ -3,6 +3,7 @@ import os
 import pickle
 import re
 import threading
+import traceback
 import time
 from multiprocessing import Process
 
@@ -14,6 +15,7 @@ subreddit = reddit.subreddit('mechmarket')
 user_df_pickle = 'userlist.pickle'
 
 trading_regex = re.compile(r'\[h\](?P<have>.*?)\[w\](?P<want>.*)')
+selling_regex = re.compile(r'\[h\](?P<have>.*?)\[w\].*paypal.*')
 vendor_regex = re.compile(r'\[vendor\](?P<title>.*)')
 groupbuy_regex = re.compile(r'\[gb\](?P<title>.*)')
 ic_regex = re.compile(r'\[ic\](?P<title>.*)')
@@ -39,6 +41,9 @@ class RedditUser():
         for item in this_user['w']:
             body += str(item_counter)+'. [W] '+item+'\n\n'
             item_counter += 1
+        for item in this_user['s']:
+            body += str(item_counter)+'. [H] '+item+' + [W] Paypal\n\n'
+            item_counter += 1
         for item in this_user['ic']:
             body += str(item_counter)+'. [IC] '+item+'\n\n'
             item_counter += 1
@@ -63,7 +68,10 @@ class RedditUser():
                            send the bot `/gb acrylic case`, or simply just `/gb acrylic`. See the table below for available commands:  \n\n'+
                             '''Command | Description | Example
                             -|-|-
-                            `/h search_term` | Search for posts where people _have_ \[H] the search_term | `/h Olivia++`
+                            `/h search_term` | Search for posts where people _have_ \[H] the search_term. Only one of `/h` \
+                            and `/s` can apply to a given item. | `/h Olivia++`
+                            `/s search_term` | Search for posts where people _have_ \[H] the search\_term and _want_ \[W] Paypal. Only one of `/h` \
+                            and `/s` can apply to a given item. | `/s Botanical`
                             `/w search_term` | Search for posts where people _want_ \[W] the search_term | `/w Lily58`
                             `/v search_term` | Search for posts from a specific vendor \[Vendor] | `/v VintKeys` |
                             `/ic search_term` | Search for posts advertising an interest check \[IC] | `/ic Acrylic Case`
@@ -74,7 +82,7 @@ class RedditUser():
                             `/va` | View your current watch list | `/va`
                             `/help` | Show available commands | `/help`
                             `/br description` | Submit a bug or feature request | `/br Track services, too!`
-                            `/unsub` | Unsubscribe from all alerts | `/unsub`\n\nIf you find this bot helpful, you can support developement by \
+                            `/unsub` | Unsubscribe from all alerts | `/unsub`\n\nIf you find this bot helpful, you can support development by \
                            [buying me a coffee :)](https://www.buymeacoffee.com/mechwatchbot). Running the server costs me $5/month \
                            on [pythonanywhere](https://www.pythonanywhere.com/pricing/) and \
                            lots of development time. Thanks!''')
@@ -110,20 +118,20 @@ def read_df_pickle(fp):
 def write_df_pickle(fp, df):
     df.to_pickle(fp, protocol=pickle.HIGHEST_PROTOCOL)
 
+def is_allowable_trade_location(user_df_row, submission):
+	return not user_df_row['l'] or '['+user_df_row['l'].lower() in submission.title.lower()
 
 def alert_interested_users(user_df, user_column, title_text, submission):
     # filtering title
     users = user_df.loc[[any(x in title_text for x in y) for y in user_df[user_column].tolist()]]
     for index, row in users.iterrows():
         # filtering location
+        if user_column in ['h', 'w', 's'] and not is_allowable_trade_location(user_df.loc[index], submission):
+        	continue
+
+        print(f"Alerting {user_df.loc[index].name} to {submission.title}", flush=True)
         try:
-            if user_column in ['h', 'w']:
-                if (user_df.loc[index]['l'] and '['+user_df.loc[index]['l'].lower() in submission.title.lower()) or not user_df.loc[index]['l']:
-                    print(f"Alerting {user_df.loc[index].name} to {submission.title}", flush=True)
-                    user_df.loc[index]['RedditUser'].alert_author(submission.title, submission)
-            else:
-                print(f"Alerting {user_df.loc[index].name} to {submission.title}", flush=True)
-                user_df.loc[index]['RedditUser'].alert_author(submission.title, submission)
+            user_df.loc[index]['RedditUser'].alert_author(submission.title, submission)
         except:
             pass
 
@@ -148,17 +156,16 @@ def inbox_monitor():
     while True:
         try:
             for item in reddit.inbox.stream(skip_existing=True):
-                user_df = read_df_pickle(user_df_pickle)
-
                 message = reddit.inbox.message(item.id)
                 author = message.author.name
                 command = message.body
 
                 print(f"{author}: {command}", flush=True)
+                user_df = read_df_pickle(user_df_pickle)
                 if author in user_df.index.tolist():
                     user_df.loc[author]['RedditUser'].update_messages(message)
                 else:
-                    user_df.loc[author] = [RedditUser(author, message), [], [], [], [], [], None]
+                    user_df.loc[author] = [RedditUser(author, message), [], [], [], [], [], [], None]
 
                 print(f"Number of users: {len(user_df)}", flush=True)
                 this_user = user_df.loc[author]['RedditUser']
@@ -186,7 +193,8 @@ def inbox_monitor():
                     this_user.send_message(f"Bye, {author}! Send me another message if you want to opt back in to alerts :)")
                     user_df = user_df.drop([author])
                     write_df_pickle(user_df_pickle, user_df)
-                elif command[0:3].lower().strip() in ['/h', '/w', '/gb', '/ic', '/v']:
+                elif command[0:3].lower().strip() in ['/h', '/w', '/gb', '/ic', '/v', '/s']:
+                    slash_command = command[0:3].lower().strip()
                     new_item = command[3:].lower().strip()
                     if new_item.startswith('<') and new_item.endswith('>'):
                         this_user.send_message("Just a heads up, you don't need the angle brackets <> around your search term. I removed them for you :)")
@@ -194,9 +202,19 @@ def inbox_monitor():
                     watch_type = command[1:3].lower().strip()
                     if new_item not in user_df.loc[author][watch_type]:
                         user_df.loc[author][watch_type].append(new_item)
-                        this_user.send_message(f"Got it. Watching for [{watch_type.upper()}] {new_item.title()} in /r/mechmarket!")
+                        if slash_command == '/s':
+                        	this_user.send_message(f"Got it. Watching for [H] {new_item.title()} + [W] Paypal in /r/mechmarket!")
+                        else:
+                        	this_user.send_message(f"Got it. Watching for [{watch_type.upper()}] {new_item.title()} in /r/mechmarket!")
                     else:
                         this_user.send_message(f"{new_item} already in watch list!")
+
+                    # Dedupe /h and /s to avoid duplicate messages.
+                    if slash_command in ['/h', '/s'] and new_item in user_df.loc[author]['h'] and new_item in user_df.loc[author]['s']:
+                    	user_df.loc[author]['h' if slash_command == '/s' else 's'].remove(new_item)
+                    	this_user.send_message(f"Overriding overlapping `{'/h' if slash_command == '/s' else '/s'}` {new_item} command. \
+                            Only one of `/h` and `/s` can apply to a given item.")
+
                     write_df_pickle(user_df_pickle, user_df)
                     this_user.get_watch_list(message)
                 elif command[0:3].lower().strip() == '/br':
@@ -215,7 +233,7 @@ def inbox_monitor():
                 else:
                     this_user.send_message("Sorry, I didn't understand your command. Send `/help` to see available commands.")
         except Exception as e:
-            print(e, flush=True)
+            print(f"Error processing inbox: {e}\n{traceback.print_exc()}\n", flush=True)
 
 
 def record_bug(author, description):
@@ -233,6 +251,8 @@ def analyze_submission(submission):
         m = trading_regex.search(title)
         alert_interested_users(user_df, 'w', m.group('want'), submission)
         alert_interested_users(user_df, 'h', m.group('have'), submission)
+        if selling_regex.search(title):
+        	alert_interested_users(user_df, 's', selling_regex.search(title).group('have'), submission)
     elif groupbuy_regex.search(title):
         alert_interested_users(user_df, 'gb', groupbuy_regex.search(title).group('title'), submission)
     elif vendor_regex.search(title):


### PR DESCRIPTION
Added a /s command to track items that are being sold. This varies slightly from /h, since /h can also contain posts where the author is only looking to trade (e.g. swap two GMK sets). I find it helpful to filter out these posts when I have nothing to trade myself.

Thanks for putting this bot together! No worries if you don't want to merge this change, but I figured it would help in case you want to add this feature at some point. Please let me know if you'd like me to make any edits, or feel free to make commits directly to the branch.

