### PR TITLE
Allow multiple removals in the same message.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.ini
 *.txt
 *.pickle
+*.pickle.lock

--- a/main.py
+++ b/main.py
@@ -329,7 +329,7 @@ def _compare_by_rm_index(command1, command2):
     if not rm_item_1.isdigit() and rm_item_2.isdigit():
         return 1
     if rm_item_1.isdigit() and rm_item_2.isdigit():
-        return 1 if rm_item_1 < rm_item_2 else -1
+        return 1 if int(rm_item_1) < int(rm_item_2) else -1
     return 0
 
 def inbox_monitor():


### PR DESCRIPTION
Sort the commands before processing to allow multiple removals in the same message. To avoid issues with ascending indexes, ensure that /rm {index} commands come first in descending index order.

Note that this change also dedupes commands.